### PR TITLE
Add theme switcher with light Copilot theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,16 @@
     <canvas id="gameCanvas" width="800" height="600"></canvas>
 
     <div id="ui-layer" class="ui-overlay">
-      <div class="score-board">Score: <span id="score">0</span></div>
+      <div class="top-bar">
+        <div class="score-board">Score: <span id="score">0</span></div>
+        <div class="theme-switcher">
+          <label for="theme-select">Theme</label>
+          <select id="theme-select" name="theme-select">
+            <option value="dark">Dark</option>
+            <option value="light">Light</option>
+          </select>
+        </div>
+      </div>
       <div id="auto-badge" class="auto-badge">AUTO PILOT ACTIVE</div>
     </div>
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,5 +1,5 @@
 export class AudioManager {
-    private ctx: AudioContext
+    private ctx!: AudioContext
     private enabled: boolean = true
 
     constructor() {

--- a/src/game/AutoPilot.ts
+++ b/src/game/AutoPilot.ts
@@ -9,7 +9,6 @@ export class AutoPilot {
     private food: Food;
     private gridWidth: number = 0;
     private gridHeight: number = 0;
-    private gridSize: number = 20;
 
     constructor(snake: Snake, food: Food, gridWidth: number, gridHeight: number) {
         this.snake = snake;

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -2,9 +2,10 @@ import { Renderer } from './Renderer';
 import { Snake } from './Snake';
 import { Food } from './Food';
 import { AutoPilot } from './AutoPilot';
+import type { ThemeName } from './themes';
+import { themes, defaultTheme } from './themes';
 
 export class Game {
-    private canvas: HTMLCanvasElement;
     private renderer: Renderer;
     private snake!: Snake;
     private food!: Food;
@@ -21,16 +22,22 @@ export class Game {
     private gridSize: number = 20;
     private gridWidth: number;
     private gridHeight: number;
+    private currentTheme: ThemeName = defaultTheme;
 
     constructor(canvas: HTMLCanvasElement) {
-        this.canvas = canvas;
-        this.renderer = new Renderer(canvas, this.gridSize);
+        this.renderer = new Renderer(canvas, this.gridSize, themes[this.currentTheme]);
         this.gridWidth = canvas.width / this.gridSize;
         this.gridHeight = canvas.height / this.gridSize;
         console.log('Game constructed. Grid:', this.gridWidth, this.gridHeight);
 
         this.bindEvents();
         this.reset();
+    }
+
+    setTheme(theme: ThemeName) {
+        this.currentTheme = theme;
+        this.renderer.setTheme(themes[theme]);
+        this.draw();
     }
 
     private bindEvents() {

--- a/src/game/Renderer.ts
+++ b/src/game/Renderer.ts
@@ -1,25 +1,30 @@
-import { Snake } from './Snake';
-import { Food } from './Food';
+import type { ThemeColors } from './themes';
 
 export class Renderer {
     private ctx: CanvasRenderingContext2D;
     private width: number;
     private height: number;
     private gridSize: number;
+    private colors: ThemeColors;
 
-    constructor(canvas: HTMLCanvasElement, gridSize: number) {
+    constructor(canvas: HTMLCanvasElement, gridSize: number, colors: ThemeColors) {
         this.ctx = canvas.getContext('2d')!;
         this.width = canvas.width;
         this.height = canvas.height;
         this.gridSize = gridSize;
+        this.colors = colors;
+    }
+
+    setTheme(colors: ThemeColors) {
+        this.colors = colors;
     }
 
     clear() {
-        this.ctx.fillStyle = '#0d1117';
+        this.ctx.fillStyle = this.colors.canvasBg;
         this.ctx.fillRect(0, 0, this.width, this.height);
 
         // Draw subtle grid
-        this.ctx.strokeStyle = '#21262d';
+        this.ctx.strokeStyle = this.colors.gridColor;
         this.ctx.lineWidth = 1;
 
         for (let x = 0; x <= this.width; x += this.gridSize) {
@@ -50,11 +55,11 @@ export class Renderer {
             );
 
             if (isHead) {
-                gradient.addColorStop(0, '#ffffff');
-                gradient.addColorStop(1, '#6366f1');
+                gradient.addColorStop(0, this.colors.snakeHeadStart);
+                gradient.addColorStop(1, this.colors.snakeHeadEnd);
             } else {
-                gradient.addColorStop(0, '#6366f1');
-                gradient.addColorStop(1, '#ec4899');
+                gradient.addColorStop(0, this.colors.snakeBodyStart);
+                gradient.addColorStop(1, this.colors.snakeBodyEnd);
             }
 
             this.ctx.fillStyle = gradient;
@@ -91,8 +96,8 @@ export class Renderer {
 
     drawFood(x: number, y: number) {
         this.ctx.shadowBlur = 15;
-        this.ctx.shadowColor = '#238636';
-        this.ctx.fillStyle = '#238636'; // GitHub Green
+        this.ctx.shadowColor = this.colors.foodGlow;
+        this.ctx.fillStyle = this.colors.foodColor;
 
         this.ctx.beginPath();
         this.ctx.arc(

--- a/src/game/themes.ts
+++ b/src/game/themes.ts
@@ -1,0 +1,37 @@
+export type ThemeName = 'dark' | 'light';
+
+export interface ThemeColors {
+    canvasBg: string;
+    gridColor: string;
+    snakeHeadStart: string;
+    snakeHeadEnd: string;
+    snakeBodyStart: string;
+    snakeBodyEnd: string;
+    foodColor: string;
+    foodGlow: string;
+}
+
+export const themes: Record<ThemeName, ThemeColors> = {
+    dark: {
+        canvasBg: '#010409',
+        gridColor: '#21262d',
+        snakeHeadStart: '#ffffff',
+        snakeHeadEnd: '#6366f1',
+        snakeBodyStart: '#6366f1',
+        snakeBodyEnd: '#ec4899',
+        foodColor: '#238636',
+        foodGlow: '#238636'
+    },
+    light: {
+        canvasBg: '#edf2ff',
+        gridColor: '#d3d9f5',
+        snakeHeadStart: '#312e81',
+        snakeHeadEnd: '#6366f1',
+        snakeBodyStart: '#8b5cf6',
+        snakeBodyEnd: '#f472b6',
+        foodColor: '#16a34a',
+        foodGlow: '#22c55e'
+    }
+};
+
+export const defaultTheme: ThemeName = 'dark';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,30 @@
 import { Game } from './game/Game'
+import type { ThemeName } from './game/themes'
+import { themes, defaultTheme } from './game/themes'
 
 document.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('gameCanvas') as HTMLCanvasElement;
   const game = new Game(canvas);
+  const themeSelect = document.getElementById('theme-select') as HTMLSelectElement | null;
 
   const startBtn = document.getElementById('start-btn');
   const restartBtn = document.getElementById('restart-btn');
   const startScreen = document.getElementById('start-screen');
   const gameOverScreen = document.getElementById('game-over-screen');
+
+  const applyTheme = (theme: ThemeName) => {
+    const validatedTheme: ThemeName = themes[theme] ? theme : defaultTheme;
+    document.documentElement.setAttribute('data-theme', validatedTheme);
+    localStorage.setItem('vibe-snake-theme', validatedTheme);
+    game.setTheme(validatedTheme);
+
+    if (themeSelect) {
+      themeSelect.value = validatedTheme;
+    }
+  };
+
+  const savedTheme = (localStorage.getItem('vibe-snake-theme') as ThemeName) || defaultTheme;
+  applyTheme(savedTheme);
 
   startBtn?.addEventListener('click', () => {
     startScreen?.classList.add('hidden');
@@ -17,5 +34,10 @@ document.addEventListener('DOMContentLoaded', () => {
   restartBtn?.addEventListener('click', () => {
     gameOverScreen?.classList.add('hidden');
     game.start();
+  });
+
+  themeSelect?.addEventListener('change', (event) => {
+    const target = event.target as HTMLSelectElement;
+    applyTheme(target.value as ThemeName);
   });
 });

--- a/src/style.css
+++ b/src/style.css
@@ -7,7 +7,22 @@
   --copilot-gradient: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
   /* Indigo to Pink */
   --grid-color: #21262d;
+  --canvas-bg: #010409;
   --ui-bg: rgba(22, 27, 34, 0.9);
+  --border-color: #30363d;
+  --muted-text: #8b949e;
+}
+
+:root[data-theme='light'] {
+  --bg-color: #f5f7fb;
+  --text-color: #0f172a;
+  --copilot-primary: #16a34a;
+  --copilot-gradient: linear-gradient(135deg, #60a5fa, #a78bfa, #f472b6);
+  --grid-color: #d3d9f5;
+  --canvas-bg: #edf2ff;
+  --ui-bg: rgba(255, 255, 255, 0.9);
+  --border-color: #cbd5e1;
+  --muted-text: #475569;
 }
 
 body {
@@ -32,7 +47,7 @@ body {
 
 canvas {
   display: block;
-  background-color: #010409;
+  background-color: var(--canvas-bg);
 }
 
 .ui-overlay {
@@ -49,6 +64,15 @@ canvas {
   box-sizing: border-box;
 }
 
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  pointer-events: auto;
+  gap: 16px;
+}
+
 .score-board {
   font-size: 24px;
   font-weight: bold;
@@ -57,8 +81,37 @@ canvas {
   padding: 10px 20px;
   border-radius: 20px;
   align-self: flex-start;
-  border: 1px solid #30363d;
+  border: 1px solid var(--border-color);
   backdrop-filter: blur(5px);
+}
+
+.theme-switcher {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  background: var(--ui-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 8px 12px;
+  pointer-events: auto;
+  color: var(--text-color);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(5px);
+}
+
+.theme-switcher label {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.theme-switcher select {
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 14px;
+  cursor: pointer;
 }
 
 .start-screen {
@@ -70,7 +123,7 @@ canvas {
   background: var(--ui-bg);
   padding: 40px;
   border-radius: 16px;
-  border: 1px solid #30363d;
+  border: 1px solid var(--border-color);
   pointer-events: auto;
   backdrop-filter: blur(10px);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
@@ -103,7 +156,7 @@ canvas {
 
 .controls-hint {
   margin-top: 20px;
-  color: #8b949e;
+  color: var(--muted-text);
   font-size: 14px;
 }
 


### PR DESCRIPTION
## Summary
- add a top-right theme switcher with dark and new light Copilot-inspired themes, remembering the chosen option
- theme the canvas renderer via shared color palettes so the board, snake, and food adjust to the selected theme
- refresh UI styling variables to support both themes and style the switcher control

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c676e7748329910e0f6cdbec9922)