### PR TITLE
Prevent arrow keys from scrolling during gameplay

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -42,7 +42,14 @@ export class Game {
 
     private bindEvents() {
         window.addEventListener('keydown', (e) => {
-            if (!this.isRunning) return;
+            const arrowKeys = new Set(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight']);
+
+            if (arrowKeys.has(e.key)) {
+                e.preventDefault();
+                if (!this.isRunning) return;
+            } else if (!this.isRunning) {
+                return;
+            }
 
             switch (e.key) {
                 case 'ArrowUp': this.snake.setDirection({ x: 0, y: -1 }); break;


### PR DESCRIPTION
## Summary
- prevent browser scroll when using arrow keys to control the snake
- maintain existing control handling while blocking default scrolling behavior

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d2da81908329a951d4635befa3f3)